### PR TITLE
assume lowercase filenames for images

### DIFF
--- a/src/infoWindow/__tests__/contentTemplate.test.ts
+++ b/src/infoWindow/__tests__/contentTemplate.test.ts
@@ -54,7 +54,7 @@ describe('infoWindow template', () => {
     const img = container.querySelector('img');
 
     expect(img).toBeDefined();
-    expect(img?.src).toEqual('http://localhost/img/FakeCafe.png');
+    expect(img?.src).toEqual('http://localhost/img/fakecafe.png');
   });
 
   it('will show a streetview if the position is defined and we have an api key', () => {

--- a/src/infoWindow/contentTemplate.ts
+++ b/src/infoWindow/contentTemplate.ts
@@ -23,10 +23,9 @@ export default ({
     </div>
     ${
       banner && logoRootPath
-        ? `<img class="map_logo" src="${logoRootPath}${banner.replace(
-            /[^A-Za-z0-9]/g,
-            '',
-          )}.${logoExtension}" alt="" />`
+        ? `<img class="map_logo" src="${logoRootPath}${banner
+            .toLowerCase()
+            .replace(/[^a-z0-9]/g, '')}.${logoExtension}" alt="" />`
         : ''
     }
     ${


### PR DESCRIPTION
My recent push to here https://gocrisp.github.io/store-locator/ is having issues with the logos in the map. It seems like this is from an inconsistency in the casing in the image path. Since we're using the "banner" directly, we wind up looking for this file
https://gocrisp.github.io/store-locator/img/JosiesCafe.png
But it's actually this
https://gocrisp.github.io/store-locator/img/josiescafe.png

For now I'm just assuming lowercase on the filename. We probably need to prescribe how to name these files anyways, so this seems correct, at least for now. The other option would be to replace `logoRootPath` and `logoExtension` with an overridable method for turning the "banner" into the logo filename. And I'm sure casing isn't necessarily going to be an issue on other prod sites.