### PR TITLE
BYT-698: public repo polish

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,3 +22,5 @@ jobs:
         with:
           branch: docs # The branch the action should deploy to.
           folder: example/dist # The folder the action should deploy.
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ dist/
 coverage/
 
 .idea/
+.env.local

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Most of the Google Maps JavaScript API options and objects are available for cus
 
 ## Run the Example App Locally
 
+You should add a `.env.local` file that contains a `GOOGLE_MAPS_API_KEY`, otherwise the Google Maps will be limited.
+
 To run the [example app](https://gocrisp.github.io/store-locator) locally, you need to build the npm package into `dist` and then run the example app. You can either run the store-locator code with `yarn dev` to watch for changes or build it once with `yarn build`, but with the former you will need to run `dev` and `example` simultaneously.
 
 ```bash

--- a/example/basic.md
+++ b/example/basic.md
@@ -23,7 +23,7 @@ import '@gocrisp/store-locator/dist/store-locator.css';
 document.addEventListener('DOMContentLoaded', () => {
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
+    loaderOptions: { apiKey: '<your Google Maps API key>' },
     geoJson: './sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>

--- a/example/basic.md
+++ b/example/basic.md
@@ -11,7 +11,7 @@ Please refer to the [README on Github](https://github.com/gocrisp/store-locator)
 
 - [Google Maps Javascript API](https://developers.google.com/maps/documentation/javascript/overview)
 - [Google Maps Basic Store Locator Tutorial](https://developers.google.com/codelabs/maps-platform/google-maps-simple-store-locator)
-- [sample.json](/sample.json)
+- [sample.json](/store-locator/sample.json)
 
 ### Code
 

--- a/example/basic.ts
+++ b/example/basic.ts
@@ -3,8 +3,8 @@ import { createStoreLocatorMap, StoreLocatorMap } from '../src';
 export default (): Promise<StoreLocatorMap> =>
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
-    geoJson: './sample.json',
+    loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
+    geoJson: './store-locator/sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>
       `img/${feature

--- a/example/index.ts
+++ b/example/index.ts
@@ -29,7 +29,7 @@ const links: Page[] = [
 
 document.addEventListener('DOMContentLoaded', async () => {
   const loader = new Loader({
-    apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk',
+    apiKey: process.env.GOOGLE_MAPS_API_KEY as string,
     libraries: ['places', 'geometry'],
   });
   await loader.load();

--- a/example/objects.md
+++ b/example/objects.md
@@ -24,7 +24,7 @@ import '@gocrisp/store-locator/dist/store-locator.css';
 document.addEventListener('DOMContentLoaded', () => {
   const { map, infoWindow, autocomplete, originMarker } = await createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
+    loaderOptions: { apiKey: '<your Google Maps API key>' },
     geoJson: './sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>

--- a/example/objects.ts
+++ b/example/objects.ts
@@ -3,8 +3,8 @@ import { createStoreLocatorMap, StoreLocatorMap } from '../src';
 export default async (): Promise<StoreLocatorMap> => {
   const storeLocator = await createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
-    geoJson: './sample.json',
+    loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
+    geoJson: './store-locator/sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>
       `img/${feature

--- a/example/options.md
+++ b/example/options.md
@@ -25,14 +25,14 @@ document.addEventListener('DOMContentLoaded', () => {
   // We need to load `google.maps.*` first so that we have access to the enum for `controlPosition` below
   // And then we use `skipLoadingGoogleMaps` so that it is not loaded twice
   const loader = new Loader({
-    apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk',
+    apiKey: '<your Google Maps API key>',
     libraries: ['places', 'geometry'],
   });
   await loader.load();
 
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
+    loaderOptions: { apiKey: '<your Google Maps API key>' },
     geoJson: {
       type: 'FeatureCollection',
       features: [

--- a/example/options.ts
+++ b/example/options.ts
@@ -3,7 +3,7 @@ import { createStoreLocatorMap, StoreLocatorMap } from '../src';
 export default (): Promise<StoreLocatorMap> =>
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
+    loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
     geoJson: {
       type: 'FeatureCollection',
       features: [

--- a/example/templates.md
+++ b/example/templates.md
@@ -19,7 +19,7 @@ import '@gocrisp/store-locator/dist/store-locator.css';
 document.addEventListener('DOMContentLoaded', () => {
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
+    loaderOptions: { apiKey: '<your Google Maps API key>' },
     geoJson: './sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     infoWindowOptions: {

--- a/example/templates.ts
+++ b/example/templates.ts
@@ -3,8 +3,8 @@ import { createStoreLocatorMap, StoreLocatorMap } from '../src';
 export default (): Promise<StoreLocatorMap> =>
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
-    loaderOptions: { apiKey: 'AIzaSyDdH3QeHDu3XGXwcIF9sMHQmbn2YS4N4Kk' },
-    geoJson: './sample.json',
+    loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
+    geoJson: './store-locator/sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     infoWindowOptions: {
       template: ({ feature }) => feature.getProperty('store'),

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dev": "microbundle watch -o dist/ --sourcemap false --compress false",
     "start": "yarn build && yarn example",
     "build-docs": "parcel build example/index.html --out-dir example/dist --public-url /store-locator/",
-    "example": "parcel example/index.html --out-dir example/dist",
+    "example": "parcel example/index.html --out-dir example/dist --public-url /store-locator/",
     "test": "jest --watch --setupTestFrameworkScriptFile=./test-setup.ts",
     "test-ci": "jest --ci --coverage --setupTestFrameworkScriptFile=./test-setup.ts",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --report-unused-disable-directives --max-warnings 0"


### PR DESCRIPTION
I noticed in one of the demos that the link to `sample.json` is broken in github pages, so I've added a matching `public-url` for local so that we can use the same path. It seems like the local version now works fine at both `http://localhost:1234` and `http://localhost:1234/store-locator/`.

And I'm attempting to remove the google maps api key from the repo. Since Dag requested that we squash all of the commits anyways, this seemed like a good opportunity to address this. This is working great locally with an `.env.local` file, but I'm not sure if I can really test this before pushing to `main`, since this relies on the workflow. (note, the key is available [here](https://console.cloud.google.com/apis/credentials/key/9a0cc678-f86e-4559-b8e4-5eb6bde720c1?authuser=1&folder=&organizationId=&project=motiion-core-prod&supportedpurview=project)). I think I set this up correctly based on the docs [here](https://github.com/marketplace/actions/github-pages), but it may need tweaking once I try to merge it.

Once this is all set I will squash the entire history.