### PR TITLE
BYT-698: Public repo polish 2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CD
 
 on:
   push:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,4 +20,5 @@ jobs:
         with:
           branch: docs # The branch the action should deploy to.
           folder: example/dist # The folder the action should deploy.
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+        env:
+          GOOGLE_MAPS_API_KEY: 'process.env.GOOGLE_MAPS_API_KEY'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,8 +1,6 @@
 name: Build Docs
 
-on:
-  push:
-    branches: [main]
+on: push
 
 jobs:
   build-and-deploy:
@@ -22,5 +20,3 @@ jobs:
         with:
           branch: docs # The branch the action should deploy to.
           folder: example/dist # The folder the action should deploy.
-        env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,6 +1,8 @@
 name: Build Docs
 
-on: push
+on:
+  push:
+    branches: [main]
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,8 @@ jobs:
         run: |
           yarn install
           yarn build-docs
+        env:
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
       - name: Deploy 🚀
         # https://github.com/marketplace/actions/deploy-to-github-pages
@@ -20,5 +22,3 @@ jobs:
         with:
           branch: docs # The branch the action should deploy to.
           folder: example/dist # The folder the action should deploy.
-        env:
-          GOOGLE_MAPS_API_KEY: 'process.env.GOOGLE_MAPS_API_KEY'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           branch: docs # The branch the action should deploy to.
           folder: example/dist # The folder the action should deploy.
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/example/basic.md
+++ b/example/basic.md
@@ -11,7 +11,7 @@ Please refer to the [README on Github](https://github.com/gocrisp/store-locator)
 
 - [Google Maps Javascript API](https://developers.google.com/maps/documentation/javascript/overview)
 - [Google Maps Basic Store Locator Tutorial](https://developers.google.com/codelabs/maps-platform/google-maps-simple-store-locator)
-- [sample.json](/store-locator/sample.json)
+- [sample.json](sample.json)
 
 ### Code
 
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: '<your Google Maps API key>' },
-    geoJson: './sample.json',
+    geoJson: 'sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>
       `img/${feature

--- a/example/basic.ts
+++ b/example/basic.ts
@@ -4,7 +4,7 @@ export default (): Promise<StoreLocatorMap> =>
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
-    geoJson: './store-locator/sample.json',
+    geoJson: 'sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>
       `img/${feature

--- a/example/objects.md
+++ b/example/objects.md
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const { map, infoWindow, autocomplete, originMarker } = await createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: '<your Google Maps API key>' },
-    geoJson: './sample.json',
+    geoJson: 'sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>
       `img/${feature

--- a/example/objects.ts
+++ b/example/objects.ts
@@ -4,7 +4,7 @@ export default async (): Promise<StoreLocatorMap> => {
   const storeLocator = await createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
-    geoJson: './store-locator/sample.json',
+    geoJson: 'sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     formatLogoPath: feature =>
       `img/${feature

--- a/example/options.md
+++ b/example/options.md
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
       zoom: 6,
       scrollwheel: false,
     },
-    formatLogoPath: () => `http://maps.google.com/mapfiles/ms/icons/blue.png`,
+    formatLogoPath: () => `https://maps.google.com/mapfiles/ms/icons/blue.png`,
     infoWindowOptions: {
       infoWindowOptions: {
         minWidth: 600,
@@ -163,7 +163,7 @@ searchBoxOptions: {
     map, // reference to the map
     visible: false, // this gets set to "true" on search
     position: map.getCenter(), // based on search results
-    icon: 'http://maps.google.com/mapfiles/ms/icons/blue.png',
+    icon: 'https://maps.google.com/mapfiles/ms/icons/blue.png',
   },
   controlPosition: google.maps.ControlPosition.TOP_RIGHT,
   template: string, // see "templates" doc

--- a/example/options.ts
+++ b/example/options.ts
@@ -35,7 +35,7 @@ export default (): Promise<StoreLocatorMap> =>
       zoom: 6,
       scrollwheel: false,
     },
-    formatLogoPath: () => `http://maps.google.com/mapfiles/ms/icons/blue.png`,
+    formatLogoPath: () => `https://maps.google.com/mapfiles/ms/icons/blue.png`,
     infoWindowOptions: {
       infoWindowOptions: {
         minWidth: 600,

--- a/example/templates.md
+++ b/example/templates.md
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: '<your Google Maps API key>' },
-    geoJson: './sample.json',
+    geoJson: 'sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     infoWindowOptions: {
       template: ({ feature }) => feature.getProperty('store'),

--- a/example/templates.md
+++ b/example/templates.md
@@ -97,7 +97,7 @@ This is the static part of the search results panel on the left of the map, so i
 ```HTML
 <h2 id="store-list-header">Nearby Locations</h2>
 <button type="button" id="map_close-store-list-button" class="close-button">
-  <img alt="Close Store List" src="http://www.google.com/intl/en_us/mapfiles/close.gif" />
+  <img alt="Close Store List" src="https://www.google.com/intl/en_us/mapfiles/close.gif" />
 </button>
 <ul id="map_store-list"></ul>
 <div id="map_store-list-message"></div>

--- a/example/templates.ts
+++ b/example/templates.ts
@@ -4,7 +4,7 @@ export default (): Promise<StoreLocatorMap> =>
   createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: process.env.GOOGLE_MAPS_API_KEY as string },
-    geoJson: './store-locator/sample.json',
+    geoJson: 'sample.json',
     mapOptions: { center: { lat: 52.632469, lng: -1.689423 }, zoom: 7 },
     infoWindowOptions: {
       template: ({ feature }) => feature.getProperty('store'),

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "microbundle -o dist/ --sourcemap false --compress false",
     "dev": "microbundle watch -o dist/ --sourcemap false --compress false",
     "start": "yarn build && yarn example",
-    "build-docs": "parcel build example/index.html --out-dir example/dist --public-url /store-locator/",
+    "build-docs": "parcel build example/index.html --out-dir example/dist --public-url /store-locator/ --no-cache",
     "example": "parcel example/index.html --out-dir example/dist",
     "test": "jest --watch --setupTestFrameworkScriptFile=./test-setup.ts",
     "test-ci": "jest --ci --coverage --setupTestFrameworkScriptFile=./test-setup.ts",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dev": "microbundle watch -o dist/ --sourcemap false --compress false",
     "start": "yarn build && yarn example",
     "build-docs": "parcel build example/index.html --out-dir example/dist --public-url /store-locator/",
-    "example": "parcel example/index.html --out-dir example/dist --public-url /store-locator/",
+    "example": "parcel example/index.html --out-dir example/dist",
     "test": "jest --watch --setupTestFrameworkScriptFile=./test-setup.ts",
     "test-ci": "jest --ci --coverage --setupTestFrameworkScriptFile=./test-setup.ts",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --report-unused-disable-directives --max-warnings 0"

--- a/src/searchBox/index.ts
+++ b/src/searchBox/index.ts
@@ -46,7 +46,7 @@ export const addSearchBoxToMap = (
     map,
     visible: false,
     position: map.getCenter(),
-    icon: 'http://maps.google.com/mapfiles/ms/icons/blue.png',
+    icon: 'https://maps.google.com/mapfiles/ms/icons/blue.png',
     ...originMarkerOptions,
   });
 

--- a/src/storeList/contentTemplate.ts
+++ b/src/storeList/contentTemplate.ts
@@ -37,7 +37,7 @@ export const storeTemplate = ({ store, formatLogoPath }: ContentTemplateArgs): s
 export const panelTemplate = `
   <h2 id="store-list-header">Nearby Locations</h2>
   <button type="button" id="${closeButtonId}" class="close-button">
-    <img alt="Close Store List" src="http://www.google.com/intl/en_us/mapfiles/close.gif" />
+    <img alt="Close Store List" src="https://www.google.com/intl/en_us/mapfiles/close.gif" />
   </button>
   <ul id="${listId}"></ul>
   <div id="${messageId}"></div>`;


### PR DESCRIPTION
I think I got it all this time! I still need to squash all of the commits once this is merged in.

The main change here was putting the Google Maps API key into a secret. There is no way we're completely hiding this because it's how the js library is loaded on the frontend. Just obscuring it a bit to make it slightly harder. It turns out all I was missing was that the `env` section should've been on the step that ran the `yarn build-docs`.

I also fixed the `sample.json` link in the github pages. The previous attempt wound up making it try to go to /store-locator/store-locator/sample.json 🙈 but making them all relative links instead of absolute at the root fixed it here and when running locally. (So then I no longer needed the `public-url` when running locally).

And I noticed we had a warning because we were loading `http` resources in the github pages version where it is served under `https` and it didn't break anything by just changing them so I just updated the links.