### PR TITLE
BYT-710: Exposing `storeList` actions and objects

### DIFF
--- a/example/objects.md
+++ b/example/objects.md
@@ -14,6 +14,18 @@ Wherever we create a new object with the Google Maps Javascript API, we are retu
 
 Note that the `originMarker` is the pin that gets placed in the center of the map on search. If you'd like to customize the markers used on the store locations, that is done via the `map` object as seen below.
 
+
+We are also exposing one non-Google object for the Search Results Pane, `storeList` which exposes a few things you may want to hook into:
+
+```TypeScript
+type StoreList = {
+  showStoreList: () => Promise<void>;
+  hideStoreList: () => void;
+  closeButton: HTMLButtonElement;
+  addListener: (type: string, listener: (element: HTMLButtonElement) => void)
+};
+```
+
 ### Code
 
 ```TypeScript
@@ -22,7 +34,7 @@ import { createStoreLocatorMap, StoreLocatorMap } from '@gocrisp/store-locator';
 import '@gocrisp/store-locator/dist/store-locator.css';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const { map, infoWindow, autocomplete, originMarker } = await createStoreLocatorMap({
+  const { map, infoWindow, autocomplete, originMarker, storeList } = await createStoreLocatorMap({
     container: document.getElementById('map-container') as HTMLElement,
     loaderOptions: { apiKey: '<your Google Maps API key>' },
     geoJson: 'sample.json',
@@ -68,6 +80,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // remove the originMarker completely (the one that appears on search)
   originMarker.setMap(null);
+
+  storeList.closeButton.addEventListener('click', () => {
+    console.log('Search Results Closed');
+  });
+
+  // only `item_click` is available
+  storeList.addListener('item_click', (button: HTMLButtonElement) => {
+    console.log(`Search Result Chosen: ${button.title}`);
+  });
 });
 ```
 

--- a/example/objects.ts
+++ b/example/objects.ts
@@ -27,7 +27,7 @@ export default async (): Promise<StoreLocatorMap> => {
     },
   });
 
-  const { map, infoWindow, autocomplete, originMarker } = storeLocator;
+  const { map, infoWindow, autocomplete, originMarker, storeList } = storeLocator;
 
   // Custom map markers per store name
   map.data.setStyle(feature => ({
@@ -48,6 +48,15 @@ export default async (): Promise<StoreLocatorMap> => {
 
   // remove the originMarker completely (the one that appears on search)
   originMarker.setMap(null);
+
+  storeList.closeButton.addEventListener('click', () => {
+    console.log('Search Results Closed');
+  });
+
+  // only `item_click` is available
+  storeList.addListener('item_click', (button: HTMLButtonElement) => {
+    console.log(`Search Result Chosen: ${button.title}`);
+  });
 
   return storeLocator;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gocrisp/store-locator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Store locator widget, intended for use with the Crisp GeoJSON connector.",
   "main": "dist/store-locator.js",
   "umd:main": "dist/store-locator.umd.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Loader, LoaderOptions } from '@googlemaps/js-api-loader';
 import { addInfoWindowListenerToMap, InfoWindowOptions } from './infoWindow';
 import { addSearchBoxToMap, SearchBoxOptions } from './searchBox';
-import { addStoreListToMapContainer, StoreListOptions } from './storeList';
+import { addStoreListToMapContainer, StoreList, StoreListOptions } from './storeList';
 
 import './styles.css';
 
@@ -30,6 +30,7 @@ export type StoreLocatorMap = {
   infoWindow: google.maps.InfoWindow;
   autocomplete: google.maps.places.Autocomplete;
   originMarker: google.maps.Marker;
+  storeList: StoreList;
 };
 
 export const defaultCenter = { lat: 39.8283, lng: -98.5795 };
@@ -92,7 +93,7 @@ export const createStoreLocatorMap = async (
     formatLogoPath,
   );
 
-  const { showStoreList } = addStoreListToMapContainer(
+  const storeList = addStoreListToMapContainer(
     container,
     map,
     showInfoWindow,
@@ -100,7 +101,7 @@ export const createStoreLocatorMap = async (
     formatLogoPath,
   );
 
-  const searchBox = addSearchBoxToMap(map, showStoreList, searchBoxOptions ?? {});
+  const searchBox = addSearchBoxToMap(map, storeList.showStoreList, searchBoxOptions ?? {});
 
-  return { map, infoWindow, ...searchBox };
+  return { map, infoWindow, ...searchBox, storeList };
 };

--- a/src/storeList/__tests__/index.test.ts
+++ b/src/storeList/__tests__/index.test.ts
@@ -34,8 +34,11 @@ describe('Store List', () => {
   describe('when we search for a location', () => {
     let map: google.maps.Map;
     let showStoreList: () => Promise<void>;
+    const extraListener = jest.fn();
 
     beforeEach(() => {
+      extraListener.mockReset();
+
       map = new google.maps.Map(container);
       const storeList = addStoreListToMapContainer(
         container,
@@ -48,6 +51,8 @@ describe('Store List', () => {
         testMaxDestinationsPerRequest,
       );
       showStoreList = storeList.showStoreList;
+
+      storeList.addListener('item_click', extraListener);
     });
 
     it('will show a store list when given a list of stores', async () => {
@@ -89,6 +94,7 @@ describe('Store List', () => {
       expect(panel).toHaveClass('open');
       userEvent.click(closeButton);
       expect(panel).not.toHaveClass('open');
+      expect(extraListener).not.toHaveBeenCalled();
     });
 
     it('will zoom in on the location when a result is clicked', async () => {
@@ -103,6 +109,7 @@ describe('Store List', () => {
       expect(map.setCenter).toHaveBeenCalledWith(expect.objectContaining({ lat: 51.479756 }));
       expect(map.setCenter).toHaveBeenCalledWith(expect.objectContaining({ lng: -3.155305 }));
       expect(map.setZoom).toHaveBeenCalledWith(13);
+      expect(extraListener).toHaveBeenLastCalledWith(cardiffItem);
     });
   });
 


### PR DESCRIPTION
I didn't expose things like this on the store list before because it's just objects in the DOM. So I kind of figured it'd be trivial to get these references once the map was initialized. But that leaves us in an awkward position in the react version since we'd have to do a `getElementById` or `querySelector` type thing to grab the DOM objects.

We specifically wanted these two actions to be listenable (when the search results are closed or when one is clicked on) for google analytics tracking in the SkinTe store locator. I wound up doing the close button first and that's why it's more separated but this could definitely be incorporated into the `addListener` if that's preferred - I kept it separate since it's more flexible at that point, you could theoretically do other things with the button 🤷‍♀️

I opted for the `addListener` pattern to keep it as similar as possible to the rest of the things we're hooking into. All of the Google Maps objects have this for their contract. This also makes it so that we could add other hooks in the future without changing the objects we're returning much. (The consistency is visible in the "Map Objects" doc page)